### PR TITLE
Add support for blocked_encryption_types

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -51,7 +51,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket                = aws_s3_bucket.this.id
   expected_bucket_owner = data.aws_caller_identity.current.account_id
   rule {
-    bucket_key_enabled = local.used_kms_key_arn == null ? null : true
+    bucket_key_enabled       = local.used_kms_key_arn == null ? null : true
+    blocked_encryption_types = var.blocked_encryption_types
     apply_server_side_encryption_by_default {
       sse_algorithm     = local.used_kms_key_arn == null ? "AES256" : "aws:kms"
       kms_master_key_id = local.used_kms_key_arn == null ? null : local.used_kms_key_arn

--- a/variables.tf
+++ b/variables.tf
@@ -149,6 +149,18 @@ variable "enable_shield_drt_access" {
   nullable    = false
 }
 
+variable "blocked_encryption_types" {
+  description = "A list of encryption types to block for uploads to this bucket. Valid values are `NONE` (block unencrypted uploads) and `SSE-C` (block client-provided encryption key uploads). Defaults to `[\"NONE\"]` to match AWS's default behavior for new buckets."
+  type        = list(string)
+  default     = ["NONE"]
+  nullable    = false
+
+  validation {
+    condition     = alltrue([for v in var.blocked_encryption_types : contains(["NONE", "SSE-C"], v)])
+    error_message = "Valid values for `blocked_encryption_types` are `NONE` and `SSE-C`."
+  }
+}
+
 variable "cors_rules" {
   description = "A list of CORS rules to apply to the S3 bucket."
   type = list(object({


### PR DESCRIPTION
From https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration:

> Starting in April 2026, Amazon S3 will automatically block server-side encryption with customer-provided keys (SSE-C) for all new buckets. Use the blocked_encryption_types argument to manage this behavior. For more information, see the SSE-C changes FAQ.
> 
> (...)
> 
> blocked_encryption_types - (Optional) List of server-side encryption types to block for object uploads. Valid values are SSE-C (blocks uploads using server-side encryption with customer-provided keys) and NONE (unblocks all encryption types). Starting in March 2026, Amazon S3 will automatically block SSE-C uploads for all new buckets.

CC @KyleKotowick 